### PR TITLE
[Fix] Search for partner or its parent to get invoice ids

### DIFF
--- a/partner_daytopay/models/res_partner.py
+++ b/partner_daytopay/models/res_partner.py
@@ -68,7 +68,9 @@ class ResPartner(models.Model):
     @api.multi
     def _get_invoice_ids(self, partner_id, type):
         return self.env['account.invoice'].search([
-            ('partner_id', '=', partner_id),
+            '|'
+            ('partner_id', '=', partner_id),            
+            ('partner_id.parent_id', '=', partner_id),
             ('state', '=', 'paid'),
             ('type', '=', type)
         ])


### PR DESCRIPTION
The module needs to include invoices sent to either partner_id or invoice address child of the partner_id.